### PR TITLE
Fixing the multiple line issue

### DIFF
--- a/jquery.expander.js
+++ b/jquery.expander.js
@@ -1,172 +1,207 @@
 /*
- * jQuery Expander plugin
- * Version 0.5  (October 7, 2009)
- * @requires jQuery v1.1.1+
- * @author Karl Swedberg
- *
- * Dual licensed under the MIT and GPL licenses:
- * http://www.opensource.org/licenses/mit-license.php
- * http://www.gnu.org/licenses/gpl.html
- *
- */
+* jQuery Expander plugin
+* Version 0.5.1  (February 23, 2010)
+* @requires jQuery v1.1.1+
+* @author Karl Swedberg
+* @author Adam Hall
+*
+* Dual licensed under the MIT and GPL licenses:
+* http://www.opensource.org/licenses/mit-license.php
+* http://www.gnu.org/licenses/gpl.html
+*
+*/
 
 
 (function($) {
 
-  $.fn.expander = function(options) {
+    $.fn.expander = function(options) {
 
-    var opts = $.extend({}, $.fn.expander.defaults, options),
-        rSlash = /\//,
-        delayedCollapse;
+        var opts = $.extend({}, $.fn.expander.defaults, options),
+            rSlash = /\//,
+            delayedCollapse;
 
-    this.each(function() {
-      var thisEl = this, $this = $(this);
-      var o = $.meta ? $.extend({}, opts, $this.data()) : opts;
-      var cleanedTag, startTags, endTags;
-      var allText = $this.html();
-      var startText = allText.slice(0, o.slicePoint).replace(/(&([^;]+;)?|\w+)$/,'');
+        this.each(function() {
+            var thisEl = this,
+                $this = $(this);
+            var o = $.meta ? $.extend({}, opts, $this.data()) : opts;
+            var cleanedTag, startTags, endTags;
+            var allText = $this.html();
+            var startText = allText.slice(0, o.slicePoint).replace(/(&([^;]+;)?|\w+)$/, '');
 
-      startTags = startText.match(/<\w[^>]*>/g);
-      
-      if (startTags) {
-        startText = allText.slice(0,o.slicePoint + startTags.join('').length).replace(/(&([^;]+;)?|\w+)$/,'');
-      }
+            startTags = startText.match(/<\w[^>]*>/g);
 
-      if (startText.lastIndexOf('<') > startText.lastIndexOf('>') ) {
-        startText = startText.slice(0,startText.lastIndexOf('<'));
-      }
-
-      var defined = {};
-      $.each(['onSlice','beforeExpand', 'afterExpand', 'onCollapse'], function(index, val) {
-        defined[val] = $.isFunction(o[val]);
-      });
-
-      var endText = allText.slice(startText.length);
-      // create necessary expand/collapse elements if they don't already exist
-      if (!$('span.details', this).length) {
-        // end script if text length isn't long enough.
-        if ( endText.replace(/\s+$/,'').split(' ').length < o.widow ) { return; }
-        // otherwise, continue...
-        if (defined.onSlice) { o.onSlice.call(thisEl); }
-        if (endText.indexOf('</') > -1) {
-          endTags = endText.match(/<(\/)?[^>]*>/g);
-          for (var i=0; i < endTags.length; i++) {
-
-            if (endTags[i].indexOf('</') > -1) {
-              var startTag, startTagExists = false;
-              for (var j=0; j < i; j++) {
-                startTag = endTags[j].slice(0, endTags[j].indexOf(' ')).replace(/\w$/,'$1>');
-                if (startTag == endTags[i].replace(rSlash,'')) {
-                  startTagExists = true;
-                }
-              }
-              if (!startTagExists) {
-                startText = startText + endTags[i];
-                var matched = false;
-                for (var s=startTags.length - 1; s >= 0; s--) {
-                  if (startTags[s].slice(0, startTags[s].indexOf(' ')).replace(/(\w)$/,'$1>') == endTags[i].replace(rSlash,'')
-                  && matched == false) {
-                    cleanedTag = cleanedTag ? startTags[s] + cleanedTag : startTags[s];
-                    matched = true;
-                  }
-                };
-              }
+            if (startTags) {
+                startText = allText.slice(0, o.slicePoint + startTags.join('').length).replace(/(&([^;]+;)?|\w+)$/, '');
             }
-          }
 
-          endText = cleanedTag && cleanedTag + endText || endText;
-        }
-        $this.html([
-          startText,
-          '<span class="read-more">',
-            o.expandPrefix,
-            '<a href="#">',
-              o.expandText,
-            '</a>',
-          '</span>',
-          '<span class="details">',
-            endText,
-          '</span>'
-          ].join('')
-        );
-      }
+            if (startText.lastIndexOf('<') > startText.lastIndexOf('>')) {
+                startText = startText.slice(0, startText.lastIndexOf('<'));
+            }
 
-      var $thisDetails = $('span.details', this),
-          $readMore = $('span.read-more', this);
+            var defined = {};
+            $.each(['onSlice', 'beforeExpand', 'afterExpand', 'onCollapse'], function(index, val) {
+                defined[val] = $.isFunction(o[val]);
+            });
 
-      $thisDetails.hide();
-      $readMore.find('a').click(function() {
-        $readMore.hide();
+            var endText = allText.slice(startText.length);
+            // create necessary expand/collapse elements if they don't already exist
+            if (!$('span.details', this).length) {
+                // end script if text length isn't long enough.
+                if (endText.replace(/\s+$/, '').split(' ').length < o.widow) {
+                    return;
+                }
+                // otherwise, continue...
+                if (defined.onSlice) {
+                    o.onSlice.call(thisEl);
+                }
+                if (endText.indexOf('</') > -1) {
+                    endTags = endText.match(/<(\/)?[^>]*>/g);
+                    for (var i = 0; i < endTags.length; i++) {
 
-        if (o.expandEffect === 'show' && !o.expandSpeed) {
-          if (defined.beforeExpand) {o.beforeExpand.call(thisEl);}
-          $thisDetails.show();
-          if (defined.afterExpand) {o.afterExpand.call(thisEl);}
-          delayCollapse(o, $thisDetails, thisEl);
-        } else {
-          if (defined.beforeExpand) {o.beforeExpand.call(thisEl);}
-          $thisDetails[o.expandEffect](o.expandSpeed, function() {
-            $thisDetails.css({zoom: ''});
-            if (defined.beforeExpand) {o.afterExpand.call(thisEl);}
-            delayCollapse(o, $thisDetails, thisEl);
-          });
-        }
-        return false;
-      });
-      if (o.userCollapse) {
-        $this
-        .find('span.details').append('<span class="re-collapse">' + o.userCollapsePrefix + '<a href="#">' + o.userCollapseText + '</a></span>');
-        $this.find('span.re-collapse a').click(function() {
+                        if (endTags[i].indexOf('</') > -1) {
+                            var startTag, startTagExists = false;
+                            for (var j = 0; j < i; j++) {
+                                startTag = endTags[j].slice(0, endTags[j].indexOf(' ')).replace(/\w$/, '$1>');
+                                if (startTag == endTags[i].replace(rSlash, '')) {
+                                    startTagExists = true;
+                                }
+                            }
+                            if (!startTagExists) {
+                                startText = startText + endTags[i];
+                                var matched = false;
+                                for (var s = startTags.length - 1; s >= 0; s--) {
+                                    if (startTags[s].slice(0, startTags[s].indexOf(' ')).replace(/(\w)$/, '$1>') == endTags[i].replace(rSlash, '') && matched == false) {
+                                        cleanedTag = cleanedTag ? startTags[s] + cleanedTag : startTags[s];
+                                        matched = true;
+                                    }
+                                };
+                            }
+                        }
+                    }
 
-          clearTimeout(delayedCollapse);
-          var $detailsCollapsed = $(this).parents('span.details');
-          reCollapse($detailsCollapsed);
-          if (defined.onCollapse) {o.onCollapse.call(thisEl, true);}
-          return false;
+                    endText = cleanedTag && cleanedTag + endText || endText;
+                }
+                $this.data("originalHTML", allText);
+                $this.data("compressedHTML", [
+                    startText,
+                    '<span class="read-more">',
+                      o.expandPrefix,
+                      '<a href="#">',
+                        o.expandText,
+                      '</a>',
+                    '</span>',
+                    '<div class="details">',
+                      endText,
+                    '</div>'
+                    ].join(''));
+                $this.html($this.data("compressedHTML"));
+                $this.bind("ReBindClicks", function() {
+                    var $thisDetails = $('.details', this),
+                        $readMore = $('span.read-more', this);
+
+                    $thisDetails.hide();
+                    $readMore.find('a').click(function() {
+                        $readMore.hide();
+                        if (o.expandEffect === 'show' && !o.expandSpeed) {
+                            if (defined.beforeExpand) {
+                                o.beforeExpand.call(thisEl);
+                            }
+                            $thisDetails.show();
+                            if (defined.afterExpand) {
+                                o.afterExpand.call(thisEl);
+                            }
+                            delayCollapse(o, $thisDetails, thisEl);
+                            completedExpand();
+                        } else {
+                            if (defined.beforeExpand) {
+                                o.beforeExpand.call(thisEl);
+                            }
+                            $thisDetails[o.expandEffect](o.expandSpeed, function() {
+                                $thisDetails.css({
+                                    zoom: ''
+                                });
+                                if (defined.beforeExpand) {
+                                    o.afterExpand.call(thisEl);
+                                }
+                                delayCollapse(o, $thisDetails, thisEl);
+                                if (o.userCollapse) {
+                                    $this.html($this.data("originalHTML"));
+                                    $this.append('<span class="re-collapse">' + o.userCollapsePrefix + '<a href="#">' + o.userCollapseText + '</a></span>');
+
+
+                                    $this.find('span.re-collapse a').click(function() {
+
+                                        clearTimeout(delayedCollapse);
+                                        $para = $(this).parent().parent();
+                                        $para.html($para.data("compressedHTML"));
+                                        $para.trigger("ReBindClicks");
+                                        //reCollapse($para);
+                                        if (defined.onCollapse) {
+                                            o.onCollapse.call(thisEl, true);
+                                        }
+                                        return false;
+                                    });
+                                }
+                            });
+                        }
+
+                        return false;
+                    });
+
+
+                });
+                $this.trigger("ReBindClicks");
+            };
+
         });
-      }
-    });
 
-    function reCollapse(el) {
-       el.hide()
-        .prev('span.read-more').show();
-    }
-    function delayCollapse(option, $collapseEl, thisEl) {
-      if (option.collapseTimer) {
-        delayedCollapse = setTimeout(function() {
-          reCollapse($collapseEl);
-          if ($.isFunction(option.onCollapse)) {option.onCollapse.call(thisEl, false);}
-          }, option.collapseTimer
-        );
-      }
-    }
+        function delayCollapse(option, $collapseEl, thisEl) {
+            if (option.collapseTimer) {
+                delayedCollapse = setTimeout(function() {
+                    reCollapse($collapseEl);
+                    if ($.isFunction(option.onCollapse)) {
+                        option.onCollapse.call(thisEl, false);
+                    }
+                }, option.collapseTimer);
+            }
+        }
 
-    return this;
-  };
+        return this;
+    };
     // plugin defaults
-  $.fn.expander.defaults = {
-    slicePoint:       100,  // the number of characters at which the contents will be sliced into two parts.
-                            // Note: any tag names in the HTML that appear inside the sliced element before
-                            // the slicePoint will be counted along with the text characters.
-    widow:            4,  // a threshold of sorts for whether to initially hide/collapse part of the element's contents.
-                          // If after slicing the contents in two there are fewer words in the second part than
-                          // the value set by widow, we won't bother hiding/collapsing anything.
-    expandText:       'read more', // text displayed in a link instead of the hidden part of the element.
-                                      // clicking this will expand/show the hidden/collapsed text
-    expandPrefix:     '&hellip; ',
-    collapseTimer:    0, // number of milliseconds after text has been expanded at which to collapse the text again
-    expandEffect:     'fadeIn',
-    expandSpeed:      '',   // speed in milliseconds of the animation effect for expanding the text
-    userCollapse:     true, // allow the user to re-collapse the expanded text.
-    userCollapseText: '[collapse expanded text]',  // text to use for the link to re-collapse the text
-    userCollapsePrefix: ' ',
+    $.fn.expander.defaults = {
+        slicePoint: 100,
+        // the number of characters at which the contents will be sliced into two parts.
+        // Note: any tag names in the HTML that appear inside the sliced element before
+        // the slicePoint will be counted along with the text characters.
+        widow: 4,
+        // a threshold of sorts for whether to initially hide/collapse part of the element's contents.
+        // If after slicing the contents in two there are fewer words in the second part than
+        // the value set by widow, we won't bother hiding/collapsing anything.
+        expandText: 'read more',
+        // text displayed in a link instead of the hidden part of the element.
+        // clicking this will expand/show the hidden/collapsed text
+        expandPrefix: '&hellip; ',
+        collapseTimer: 0,
+        // number of milliseconds after text has been expanded at which to collapse the text again
+        expandEffect: 'fadeIn',
+        expandSpeed: '300',
+        // speed in milliseconds of the animation effect for expanding the text
+        userCollapse: true,
+        // allow the user to re-collapse the expanded text.
+        userCollapseText: '[collapse expanded text]',
+        // text to use for the link to re-collapse the text
+        userCollapsePrefix: ' ',
 
-    /* CALLBACK FUNCTIONS
+/* CALLBACK FUNCTIONS
         ** all functions have the this keyword mapped to the element that called .expander()
-    */
-    onSlice: null, // function() {}
-    beforeExpand: null, // function() {},
-    afterExpand: null, // function() {},
-    onCollapse: null // function(byUser) {}
-  };
+        */
+        onSlice: null,
+        // function() {}
+        beforeExpand: null,
+        // function() {},
+        afterExpand: null,
+        // function() {},
+        onCollapse: null // function(byUser) {}
+    };
 })(jQuery);


### PR DESCRIPTION
Hi kswedberg.

I have made a slight modification to the code to change the HTML after expanding truncated text to the originalHTML that was in the document. This means any special formatting, like line breaks and CSS styles are honoured.

You can try it by using the plugin on a div that has multiple P elements inside.

To perform this, I have had to add a data property to the original matched node that stores the HTML before it is truncated, and after it is truncated. I have also needed to create an event called "ReBindClicks". This is an event that occurs after the expander has initially loaded, and upon every subsequent Collapse event to rebind the jquery events to the HTML.

Please have a look at the code, it's based on your latest version and works exactly as before.

If you have any further enhancements, I'm happy to continue working on it.

You can play with a demo here:
http://jsfiddle.net/digiguru/PVsXd/4/

Many Thanks
