### PR TITLE
Do not shorten text that is already short enough

### DIFF
--- a/jquery.expander.js
+++ b/jquery.expander.js
@@ -45,7 +45,7 @@
       // create necessary expand/collapse elements if they don't already exist
       if (!$('span.details', this).length) {
         // end script if text length isn't long enough.
-        if ( endText.replace(/\s+$/,'').split(' ').length < o.widow ) { return; }
+        if ( endText.replace(/\s+$/,'').split(' ').length < o.widow || allText.length < o.slicePoint ) { return; }
         // otherwise, continue...
         if (defined.onSlice) { o.onSlice.call(thisEl); }
         if (endText.indexOf('</') > -1) {


### PR DESCRIPTION
When the text is shorter than the given slice length, it shouldn't be "shortened" further.  I was having problems with the "show more" button showing up even though there was no more text left.  This fixes the problem.

This should fix issue #7.
