### PR TITLE
Trim end of summary so that we can use an ellipsis properly at the end

### DIFF
--- a/jquery.expander.js
+++ b/jquery.expander.js
@@ -350,7 +350,7 @@
       if (preserveWords) {
         txt = txt.replace(rAmpWordEnd,'');
       }
-      return txt;
+      return $.trim(txt);
     }
 
     function reCollapse(o, el) {


### PR DESCRIPTION
(e.g. "summary ..." -> "summary...")

If you enter an ellipsis as your expandPrefix you probably want to come right after your word, in accordance with English grammar.

If you actually do want a space there, you can just use " &hellip; " with the space at the beginning as expandPrefix.
