### PR TITLE
Add EditorConfig file defining indentation and newline style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://EditorConfig.org
+
+root = true
+
+[*]
+end_of_line = LF
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[demo/*.html]
+indent_style = space
+indent_size = 2
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[/test/qunit/*]
+indent_style = tab


### PR DESCRIPTION
This `.editorconfig` file defines the indentation and line ending style used in this project.

[EditorConfig](http://editorconfig.org) is a file format used for defining coding style (I co-created this format last year).  There are currently plugins available for Vim, Emacs, and [a slew of other editors](http://editorconfig.org/#download).  The format itself is well-tested though not yet widely used.

Code contributors using an EditorConfig plugin will find adhering to your coding style more natural with this file present (especially those who usually use tabs or 4 spaces for indentation).

Also, we would love any feedback on EditorConfig if you have any opinions on the project.
