### PR TITLE
Added the ability to class more/less anchors

### DIFF
--- a/jquery.expander.js
+++ b/jquery.expander.js
@@ -35,6 +35,10 @@
       moreClass: 'read-more',
       lessClass: 'read-less',
 
+      // class names for <a> around "read-more" link and "read-less" link
+      moreLinkClass: 'more-link',
+      lessLinkClass: 'less-link',
+        
       // number of milliseconds after text has been expanded at which to collapse the text again.
       // when 0, no auto-collapsing
       collapseTimer: 0,
@@ -108,6 +112,8 @@
               detailSelector = el + '.' + o.detailClass,
               moreClass = o.moreClass + '',
               lessClass = o.lessClass + '',
+              moreLinkClass = o.moreLinkClass + '',
+              lessLinkClass = o.lessLinkClass + '',
               expandSpeed = o.expandSpeed || 0,
               allHtml = removeSpaces( $this.html() ),
               allText = removeSpaces( $this.text() ),
@@ -279,7 +285,7 @@
           if ( o.userCollapse && !$this.find(o.lessSelector).length ) {
             $this
             .find(detailSelector)
-            .append('<span class="' + o.lessClass + '">' + o.userCollapsePrefix + '<a href="#">' + o.userCollapseText + '</a></span>');
+            .append('<span class="' + o.lessClass + '">' + o.userCollapsePrefix + '<a href="#" class="'+ o.lessLinkClass +'">' + o.userCollapseText + '</a></span>');
           }
 
           $this
@@ -360,7 +366,7 @@
 
     function buildMoreLabel(o) {
       var ret = '<span class="' + o.moreClass + '">' + o.expandPrefix;
-      ret += '<a href="#">' + o.expandText + '</a></span>';
+      ret += '<a href="#" class="' + o.moreLinkClass + '">' + o.expandText + '</a></span>';
       return ret;
     }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -97,12 +97,19 @@ test('text and class names', function() {
     expandPrefix: '', //'&hellip; ',
     detailClass:  'expd',   //'details',
     moreClass:    'more', //'read-more',
-    lessClass:    'less'  //'read-less'
+    lessClass:    'less',  //'read-less',
+    moreLinkClass: 'linkMore', //'more-link'
+    lessLinkClass: 'linkLess' //'less-link'
+
   });
   equal(dd.find('.more').length, 1, 'read more class changed');
   equal(dd.find('.read-more').length, 0, 'read more class changed');
   equal(dd.find('.less').length, 1, 'read less class changed');
   equal(dd.find('.read-less').length, 0, 'read less class changed');
+  equal(dd.find('.linkMore').length, 1, 'more link class changed');
+  equal(dd.find('.more-link').length, 0, 'more link class changed');
+  equal(dd.find('.linkLess').length, 1, 'less link class changed');
+  equal(dd.find('.less-link').length, 0, 'less link class changed');
   equal(dd.find('.expd').length, 1, 'details class changed');
   equal(dd.find('.details').length, 0, 'details class changed');
   equal(dd.find('.more a').text(), 'foo', 'expandText changed');


### PR DESCRIPTION
A number of plugins and frameworks (eg: Twitter Bootstrap) look for class hooks on specific tags. Added the ability to add classes to the more/less anchors. Updated tests. 

Signed-off-by: Jonathan Bruder jbruder@gmail.com
