### PR TITLE
Added behavior to consider anchor tags when slicing, Fixes #87. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.DS_Store
 lib/*
 /index.html
+node_modules

--- a/jquery.expander.js
+++ b/jquery.expander.js
@@ -1,3 +1,4 @@
+
 /*!
  * Expander - v1.4.8 - 2014-05-01
  * http://plugins.learningjquery.com/expander/
@@ -81,7 +82,7 @@
         rOpenCloseTag = /<\/?(\w+)[^>]*>/g,
         rOpenTag = /<(\w+)[^>]*>/g,
         rCloseTag = /<\/(\w+)>/g,
-        rLastCloseTag = /(<\/[^>]+>)\s*$/,
+        rLastCloseTag = /(<\/([^>]+)>)\s*$/,
         rTagPlus = /^(<[^>]+>)+.?/,
         rMultiSpace = /\s\s+/g,
         delayedCollapse;
@@ -336,11 +337,15 @@
     // utility functions
     function buildHTML(o, blocks) {
       var el = 'span',
-          summary = o.summary;
+          summary = o.summary,
+          closingTagParts = rLastCloseTag.exec(summary),
+          closingTag = closingTagParts ? closingTagParts[2].toLowerCase() : '';
       if ( blocks ) {
         el = 'div';
         // if summary ends with a close tag, tuck the moreLabel inside it
-        if ( rLastCloseTag.test(summary) && !o.expandAfterSummary) {
+
+        if ( closingTagParts && closingTag !== 'a' && !o.expandAfterSummary) {
+
           summary = summary.replace(rLastCloseTag, o.moreLabel + '$1');
         } else {
         // otherwise (e.g. if ends with self-closing tag) just add moreLabel after summary

--- a/test/index.html
+++ b/test/index.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="qunit/qunit.css" type="text/css" media="screen">
 
   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.min.js"></script>
-  <script>!window.jQuery && document.write(unescape('%3Cscript src="/lib/jquery.js"%3E%3C/script%3E'));</script>
+
 
   <script src="http://code.jquery.com/qunit/qunit-1.11.0.js"></script>
   <script src="../jquery.expander.js"></script>
@@ -120,6 +120,14 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
         </ul>
       </div>
     </div>
+    <div id="anchor-test">
+        <p>For The Art Institutes Privacy Policy and Accreditation and Licensing information:
+        </p>
+        <a onclick="window.open('http://www.artinstitutes.edu/accreditation-and-licensing.aspx?h=1','window','width=850, height=850, toolbar=0,menubar=0,location=0, scrollbars=1, resizable=1'); return false;" href="javascript:%20void();">Accreditation &amp; Licensing</a>
+        <br>
+        <a onclick="window.open('http://www.artinstitutes.edu/privacy-policy.aspx?h=1','window','width=850, height=850, toolbar=0,menubar=0,location=0, scrollbars=1, resizable=1'); return false;" href="javascript:%20void();">Privacy Policy</a>
+    </div>
+
   </div>
 </body>
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -215,6 +215,7 @@ test('destroy expander', function() {
 module('multiple blocks', {
   setup: function() {
     this.ex = $('#hello').expander();
+    this.anchor = $('#anchor-test').expander();
   }
 });
 
@@ -231,6 +232,15 @@ test('text slicing with word boundaries', function() {
   equal(txt.length, 97, 'sliced summary text to proper length');
 });
 
+test('Read more link not nested in closing link', function() {
+
+  if ($('.read-more .more-link').length === 1) {
+    ok(false);
+  } else {
+    ok(true);
+  }
+});
+
 test('destroy expander', function() {
   expect(6);
   this.ex.expander('destroy');
@@ -241,6 +251,7 @@ test('destroy expander', function() {
   ok( (/^\s*Beatrice's Answer/).test(this.ex.text()), 'summary text preserved' );
   ok( (/Much Ado About Nothing/).test(this.ex.text()), 'detail text preserved' );
 });
+
 
 /* ODD HTML */
 module('odd html', {


### PR DESCRIPTION
Expander will now bother to check to see if the tag it's adding a read-more link into is an anchor tag (which would break the read-more), and will now avoid it.

Added test to check if expander places a read more inside an anchor link. 

Thanks to @kswedberg for getting me on the "right tree" to bark up.
