### PR TITLE
update documentation to include wordCount options, and workarounds for inherent issues. Resolves #45

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,10 +98,10 @@ effects options.
 
 ## Workarounds for inherent issues
 
-* It is not possible to change the text inside an element that has had expander already applied to it, because elements are already split up into detail and summary texts. Almost everything that happens during initialization in expander needs to be repeated on a change in content to properly display the altered content. To do this expander first needs to be destroyed, then reinitialized on the content.
+* It is not possible to change the text inside an element that has had expander already applied to it, because elements are already split up into detail and summary texts. Almost everything that happens during initialization in expander needs to be repeated on a change in content to properly display the altered content. To do this expander first needs to be destroyed, then reinitialized on the content (with settings).
   ```js
   $('#sliceonchar').expander('destroy').html( "<p>The HTML you want to replace the current html with goes here</p>" ).expander(
-    showWordCount: 'true',
+    showWordCount: true,
     preserveWords: false,
     slicePoint: 30
   );


### PR DESCRIPTION
Correct me if I'm wrong, but I'm pretty sure the only way that content inside "expandered" content can be updated (#45) is using almost all the initialization functions over again to shift content in detail and summary text. 

Also, some documentation for word count that was not added back when it was merged.
