### PR TITLE
Add support to non-english characters (UTF-8)

### DIFF
--- a/jquery.expander.js
+++ b/jquery.expander.js
@@ -88,7 +88,7 @@
 
     var opts = $.extend({}, $.expander.defaults, options),
         rSelfClose = /^<(?:area|br|col|embed|hr|img|input|link|meta|param).*>$/i,
-        rAmpWordEnd = opts.wordEnd || /(&(?:[^;]+;)?|[a-zA-Z\u00C0-\u0100]+)$/,
+        rAmpWordEnd = opts.wordEnd || /(&(?:[^;]+;)?|[a-zA-Z\u00C0-\u0100]+|[^\u0000-\u007F]+)$/,
         rOpenCloseTag = /<\/?(\w+)[^>]*>/g,
         rOpenTag = /<(\w+)[^>]*>/g,
         rCloseTag = /<\/(\w+)>/g,


### PR DESCRIPTION
When options preserveWords = true, content split is not correct, if content contains non-english characters.
This pull-request fix this problem, at least the Russian letters are handled correctly.
