### PR TITLE
AMD and CommonJS support.

### DIFF
--- a/jquery.expander.js
+++ b/jquery.expander.js
@@ -5,7 +5,17 @@
  * Licensed MIT (http://www.opensource.org/licenses/mit-license.php)
  */
 
-(function($) {
+(function (factory) {
+  if (typeof define === "function" && define.amd) {
+    define(function () {
+      return factory;
+    });
+  } else if (typeof module === "object" && typeof module.exports === "object") {
+    exports = factory;
+  } else {
+    factory(jQuery);
+  }
+})(function($) {
   $.expander = {
     version: '1.4.14',
     defaults: {
@@ -476,4 +486,4 @@
 
   // plugin defaults
   $.fn.expander.defaults = $.expander.defaults;
-})(jQuery);
+});

--- a/readme.md
+++ b/readme.md
@@ -137,6 +137,19 @@ effects options.
     }
   });
   ```
+  
+## Injecting with CommonJS or AMD
+
+```js
+// CommonJS
+var jQuery = require('jquery');
+require('jquery-expander')(jQuery);
+
+// AMD
+define(['jquery', 'jquery-expander'], function (jQuery, expander) {
+  expander(jQuery)
+})
+```
 
 ## Demo
 


### PR DESCRIPTION
People often use WebPack, Browserify, JSPM, Steal.JS or any other bundler. Supporting AMD and CommonJS is useful.